### PR TITLE
User/rgale/parser

### DIFF
--- a/src/ast/function_ast.cpp
+++ b/src/ast/function_ast.cpp
@@ -41,5 +41,5 @@ llvm::Function *FunctionAST::codegen(CodeGenContext &ctx)
 bool FunctionAST::operator==(const FunctionAST &other) const
 {
     // TODO(sitow): Check function body
-    return Proto == other.Proto;
+    return *Proto == *other.Proto;
 }

--- a/src/compile.cpp
+++ b/src/compile.cpp
@@ -26,7 +26,7 @@ int compile(std::string filename)
         }
     }
 
-    auto ast = parse(tokens.to_vec());
+    auto ast = parse(tokens);
 
     return EXIT_SUCCESS;
 }

--- a/src/parse.cpp
+++ b/src/parse.cpp
@@ -1,10 +1,50 @@
 #include "parse.hpp"
-
 #include "lexer.hpp"
+#include <iostream>
+#include <stdexcept>
 
-// TODO: This return type might need to change
-unique_ptr<FunctionAST> parse(TokenStream stream)
+std::unique_ptr<FunctionAST> parseFunction(TokenStream &stream);
+std::vector<std::string> parseVarInput(TokenStream &stream);
+
+std::unique_ptr<FunctionAST> parse(TokenStream &stream)
 {
-    stream.next();
-    return nullptr;
+    auto tok = stream.next();
+    if (tok.getkey() == "KEYWORD" && tok.getvalue() == "FUNCTION")
+    {
+        std::cerr << "Parsing function..." << std::endl;
+        return parseFunction(stream);
+    }
+    throw std::invalid_argument("Expected keyword FUNCTION, but got " + tok.getkey() + " " + tok.getvalue() + " instead");
+}
+
+std::unique_ptr<FunctionAST> parseFunction(TokenStream &stream)
+{
+    auto tok = stream.next();
+    if (tok.getkey() != "IDENTIFIER")
+    {
+        throw std::invalid_argument("Expected function name identifier, but got token " + tok.getkey() + " instead");
+    }
+    auto functionName = tok.getvalue();
+
+    tok = stream.next();
+    if (tok.getkey() != "KEYWORD" || tok.getvalue() != "END_FUNCTION")
+    {
+        throw std::invalid_argument("Expected keyword END_FUNCTION but got " + tok.getkey() + " " + tok.getvalue() + " instead");
+    }
+
+    tok = stream.next();
+    if (tok.getkey() != "SPECIAL_CHARACTER" || tok.getvalue() != ";")
+    {
+        throw std::invalid_argument("Expected special character ; but got " + tok.getkey() + " " + tok.getvalue() + " instead");
+    }
+
+    auto prototype = std::make_unique<PrototypeAST>(functionName, std::vector<std::string>());
+    auto function = std::make_unique<FunctionAST>(std::move(prototype), nullptr);
+
+    return function;
+}
+
+std::vector<std::string> parseVarInput(TokenStream &stream)
+{
+    return std::vector<std::string>();
 }

--- a/src/parse.cpp
+++ b/src/parse.cpp
@@ -3,8 +3,8 @@
 #include "lexer.hpp"
 
 // TODO: This return type might need to change
-std::unique_ptr<FunctionAST> parse(std::vector<Token> tokens)
+unique_ptr<FunctionAST> parse(TokenStream stream)
 {
-    // TODO: Implement parsing
+    stream.next();
     return nullptr;
 }

--- a/src/parse.hpp
+++ b/src/parse.hpp
@@ -5,6 +5,6 @@
 #include "token.hpp"
 #include "token_stream.hpp"
 
-std::unique_ptr<FunctionAST> parse(TokenStream);
+std::unique_ptr<FunctionAST> parse(TokenStream &);
 
 #endif

--- a/src/parse.hpp
+++ b/src/parse.hpp
@@ -1,11 +1,10 @@
 #ifndef PARSE_HPP
 #define PARSE_HPP
 
-#include <vector>
-
 #include "ast/function_ast.hpp"
 #include "token.hpp"
+#include "token_stream.hpp"
 
-std::unique_ptr<FunctionAST> parse(std::vector<Token>);
+std::unique_ptr<FunctionAST> parse(TokenStream);
 
 #endif

--- a/src/token.hpp
+++ b/src/token.hpp
@@ -1,7 +1,6 @@
 #ifndef TOKEN_H
 #define TOKEN_H
 #include <string>
-#include <vector>
 
 // where/how the keywords are going to be saved
 struct Token

--- a/src/token_stream.cpp
+++ b/src/token_stream.cpp
@@ -13,3 +13,8 @@ void TokenStream::print()
         token.print();
     }
 }
+
+Token TokenStream::next()
+{
+    return tokens[index++];
+}

--- a/src/token_stream.hpp
+++ b/src/token_stream.hpp
@@ -1,3 +1,4 @@
+#pragma once
 #include <vector>
 
 #include "token.hpp"
@@ -7,8 +8,10 @@ class TokenStream
   public:
     void push(Token);
     void print();
+    Token next();
     std::vector<Token> to_vec() { return tokens; };
 
   private:
     std::vector<Token> tokens;
+    int index = 0;
 };

--- a/test/parse_function.cpp
+++ b/test/parse_function.cpp
@@ -54,3 +54,27 @@ TEST(Parse, DISABLED_Function)
 
     ASSERT_EQ(*function, *ast);
 };
+
+TEST(Parse, Function_no_Arguments)
+{
+    std::vector<Token>
+        tok_vec{
+            Token("KEYWORD", "FUNCTION"),
+            Token("IDENTIFIER", "F_Sample"),
+            Token("KEYWORD", "END_FUNCTION"),
+            Token("SPECIAL_CHARACTER", ";"),
+        };
+
+    TokenStream stream;
+    for (auto const &tok : tok_vec)
+    {
+        stream.push(tok);
+    }
+
+    auto ast = parse(stream);
+
+    std::vector<std::string> arg_names = {};
+    auto prototype = std::make_unique<PrototypeAST>("F_Sample", std::move(arg_names));
+    auto function = std::make_unique<FunctionAST>(std::move(prototype), nullptr);
+    ASSERT_EQ(*function, *ast);
+};

--- a/test/parse_function.cpp
+++ b/test/parse_function.cpp
@@ -37,7 +37,13 @@ TEST(Parse, DISABLED_Function)
             Token("SPECIAL_CHARACTER", ";"),
         };
 
-    auto ast = parse(tok_vec);
+    TokenStream stream;
+    for (auto const &tok : tok_vec)
+    {
+        stream.push(tok);
+    }
+
+    auto ast = parse(stream);
 
     std::vector<std::string> arg_names = {"x", "y"};
     auto prototype = std::make_unique<PrototypeAST>("F_Sample", std::move(arg_names));


### PR DESCRIPTION
This pull request adds some basic implementation to the parse function, as well as modify some existing files:
 - It implements a token stream in the test file as well as in parse_function.cpp
 - Comments out much of the manually tokenized example in parse_function.cpp
 - Modifies the next() method in token_stream.cpp
 -  Adds the ability to parse functions into parse.cpp, but will need dedicated classes later on.